### PR TITLE
Update assertExpandedFieldIsPresentWithValue()

### DIFF
--- a/tests/E2E/IuSubmissions/ExtendedTest.php
+++ b/tests/E2E/IuSubmissions/ExtendedTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\DomCrawler\Field\FormField;
 use Symfony\Component\DomCrawler\Form;
 use TRegx\CleanRegex\Exception\SubjectNotMatchedException;
 use TRegx\CleanRegex\Match\Details\Detail;
+use TRegx\CleanRegex\Pattern;
 
 class ExtendedTest extends AbstractTestWithEM
 {
@@ -284,13 +285,13 @@ class ExtendedTest extends AbstractTestWithEM
     private static function assertExpandedFieldIsPresentWithValue(?string $value, Field $field, string $htmlBody): void
     {
         if (in_array($field, self::EXPANDED)) {
-            $array = '\[]';
+            $array = '[]';
             self::assertNotNull($value);
         } else {
             $array = '';
         }
 
-        $selected = pattern('<input[^>]*name="iu_form\['.$field->modelName().']'.$array.'"[^>]*value="(?<value>[^"]+)"[^>]*>')
+        $selected = Pattern::inject('<input[^>]*name="iu_form\[@]@"[^>]*value="(?<value>[^"]+)"[^>]*>', [$field->modelName(), $array])
             ->match($htmlBody)->flatMapAssoc(fn (Detail $detail): array => [$detail->get('value') => str_contains($detail->text(), 'checked="checked"')]);
 
         $expected = StringList::unpack($value);

--- a/tests/E2E/IuSubmissions/ExtendedTest.php
+++ b/tests/E2E/IuSubmissions/ExtendedTest.php
@@ -291,8 +291,7 @@ class ExtendedTest extends AbstractTestWithEM
         }
 
         $selected = pattern('<input[^>]*name="iu_form\['.$field->modelName().']'.$array.'"[^>]*value="(?<value>[^"]+)"[^>]*>')
-            ->match($htmlBody)->map(fn (Detail $detail): array => [$detail->group('value')->text(), str_contains($detail->text(), 'checked="checked"')]);
-        $selected = Arrays::assoc($selected);
+            ->match($htmlBody)->flatMapAssoc(fn (Detail $detail): array => [$detail->get('value') => str_contains($detail->text(), 'checked="checked"')]);
 
         $expected = StringList::unpack($value);
 


### PR DESCRIPTION
I had to put these two changes in one PR, because if I put it separately, you'd get conflicts.

1. I saw you used `map()` to return something of a tuple (`[$one, $twp]`) and then used your `Arrays::assoc()` to I believe make it a key-value map? If so, you can use `flatMapAssoc`. Or also `flatMap()`, it's described [here](https://t-regx.com/docs/match-flat-map/#mapping-with-keys).
2. I also saw you sometimes like to build your own patterns! That's super cool. But remember that if you want to treat something like plaintext, like this `[]` in your `$array` variable, you could use prepared patterns. Simplest of which is `Pattern::inject()`. It basically takes the args list, quotes it, and puts it in place of `@` placeholder (+ does some more PHP fixing). It's something like Prepared Statements from SQL but for regexps ;)