### PR TITLE
Refactor preg::split() to Pattern.cut()

### DIFF
--- a/src/Utils/StringBuffer.php
+++ b/src/Utils/StringBuffer.php
@@ -7,7 +7,9 @@ namespace App\Utils;
 use RuntimeException;
 use Symfony\Component\String\AbstractString;
 use Symfony\Component\String\UnicodeString;
-use TRegx\SafeRegex\Exception\PregException;
+use TRegx\CleanRegex\Exception\UnevenCutException;
+use TRegx\CleanRegex\Pattern;
+use TRegx\Exception\MalformedPatternException;
 use TRegx\SafeRegex\preg;
 use UnexpectedValueException;
 
@@ -16,9 +18,9 @@ class StringBuffer
     private AbstractString $buffer;
 
     /**
-     * @var array<string, string>
+     * @var array<string, Pattern>
      */
-    private array $delimitedCache = [];
+    private array $terminatorPatternCache = [];
 
     public function __construct(string $buffer)
     {
@@ -65,27 +67,22 @@ class StringBuffer
     public function readUntilRegexp(string $terminator, bool $trimWhitespaceAfterwards = true): string
     {
         try {
-            $delimitedPattern = $this->delimitedCache[$terminator] ??= pattern($terminator)->delimited();
+            $pattern = $this->terminatorPatternCache[$terminator] ??= pattern($terminator);
 
-            /**
-             * @var string[] $parts
-             */
-            $parts = preg::split($delimitedPattern, $this->buffer->toString(), 2);
-        } catch (PregException $e) {
+            [$one, $two] = $pattern->cut($this->buffer->toString());
+        } catch (MalformedPatternException $e) {
             throw new RuntimeException("Terminator '$terminator' is not a valid regexp: {$e->getMessage()}");
-        }
-
-        if (count($parts) < 2) {
+        } catch (UnevenCutException $e) {
             throw new UnexpectedValueException("Unable to find '$terminator' in the remaining buffer '$this->buffer'");
         }
 
-        $this->buffer = new UnicodeString($parts[1]);
+        $this->buffer = new UnicodeString($two);
 
         if ($trimWhitespaceAfterwards) {
             $this->skipWhitespace();
         }
 
-        return $parts[0];
+        return $one;
     }
 
     public function readCharacter(): string


### PR DESCRIPTION
Not sure about this change! I saw that you're trying to split your value into two pieces, there's a method in `Pattern` specfically for that, it splits a value into exactly two pieces, and throws `UnevenCutException` if there is less or more. The idea is so it can be used like that:

```php
[$one,$two] = $patter->cut($subject);
```

It may be applicable to your case, or may not, because I saw you're not using `=== 2`, but `< 2`. So it's possible `Pattern.cut()` doesn't work here for you, which is totally fine!

If it doesn't work, simply close the PR :)