### PR TITLE
Use `PatternList.prune()` instead of iterating `Pattern.prune()`

### DIFF
--- a/src/Tracking/TextPreprocessor.php
+++ b/src/Tracking/TextPreprocessor.php
@@ -12,18 +12,22 @@ use JsonException;
 use Nette\Utils\Arrays;
 use Symfony\Component\DomCrawler\Crawler;
 use TRegx\CleanRegex\Pattern;
+use TRegx\CleanRegex\PatternList;
 
 class TextPreprocessor
 {
+    private readonly PatternList $falsePositivePatterns;
     private readonly Detector $detector;
 
     /**
      * @param Pattern[] $falsePositivePatterns
      */
     public function __construct(
-        private readonly array $falsePositivePatterns,
+        array                         $falsePositivePatterns,
         private readonly Replacements $replacements,
-    ) {
+    )
+    {
+        $this->falsePositivePatterns = Pattern::list($falsePositivePatterns);
         $this->detector = new Detector();
     }
 
@@ -36,7 +40,7 @@ class TextPreprocessor
         $contents = strtolower($contents);
         $contents = $this->applyReplacements($contents);
         $contents = self::replaceArtisanName($artisanName, $contents);
-        $contents = $this->removeFalsePositives($contents);
+        $contents = $this->falsePositivePatterns->prune($contents);
         $contents = $this->applyFilters($url, $contents);
 
         return new Text($inputText, $contents);
@@ -109,15 +113,6 @@ class TextPreprocessor
         }
 
         return $inputText;
-    }
-
-    private function removeFalsePositives(string $contents): string
-    {
-        foreach ($this->falsePositivePatterns as $pattern) {
-            $contents = $pattern->prune($contents);
-        }
-
-        return $contents;
     }
 
     private function applyReplacements(string $contents): string


### PR DESCRIPTION
This doesn't actually change much; but is a performance improvement.

When you iterate `Pattern` and call `prune()` each time, you call PHP regex API `n` times, as many times as you have patterns in the array. 

When you use `PatternList.prune()` it will prune all the patterns using a single call. 

But apart from the performance gain, they work exactly the same.

Documentation on `PatternList`: https://t-regx.com/docs/pattern-list