### PR TITLE
Use search().all(), instead of match().map()

### DIFF
--- a/src/Utils/Data/Fixer/PayMethodFixer.php
+++ b/src/Utils/Data/Fixer/PayMethodFixer.php
@@ -37,7 +37,7 @@ class PayMethodFixer extends AbstractListFixer
         return [
             'wise.com',
             'boosty.to',
-            ...$this->nsp->match($subject)->map(fn (Detail $detail) => $detail->text()),
+            ...$this->nsp->search($subject)->all(),
         ];
     }
 }


### PR DESCRIPTION
All methods `Pattern.match()` operate with `Detail` (`all()`, `first()`, `map()`, etc.) But sometimes you only need raw match, like in this case.

For that, we have `Pattern.search()`. `Pattern.search()` has exactly the same methods as `Pattern.match()`, but only returns `string` (which is the whole match). When you often use `Detail.text()`, consider `Pattern.search()`.

---

![match](https://user-images.githubusercontent.com/13367735/198728405-34a7251a-623e-49f8-9b5b-c8e45739bd6a.png)
![search](https://user-images.githubusercontent.com/13367735/198728413-bf84fd01-2bef-4041-8619-c0daac9f1e08.png)

