### PR TITLE
Upgrade T-Regx to 0.41.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "google/recaptcha": "^1.2",
         "nette/utils": "^3.2",
         "phpoffice/phpspreadsheet": "^1.17",
-        "rawr/t-regx": "0.39.*",
+        "rawr/t-regx": "0.41.0",
         "sensio/framework-extra-bundle": "*",
         "symfony/apache-pack": "^1.0",
         "symfony/console": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5265681a7d530647a82a7371bb6c291",
+    "content-hash": "ce1a72a2fdd610db9ec4597270bc4c89",
     "packages": [
         {
             "name": "azjezz/psl",
@@ -2379,16 +2379,16 @@
         },
         {
             "name": "rawr/t-regx",
-            "version": "0.39.0",
+            "version": "0.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/T-Regx/T-Regx.git",
-                "reference": "97541ea146f2af803930fdaf26c1a421ba10a671"
+                "reference": "381b33ad81395dfac4ad6bfd8a5730869216964d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/T-Regx/T-Regx/zipball/97541ea146f2af803930fdaf26c1a421ba10a671",
-                "reference": "97541ea146f2af803930fdaf26c1a421ba10a671",
+                "url": "https://api.github.com/repos/T-Regx/T-Regx/zipball/381b33ad81395dfac4ad6bfd8a5730869216964d",
+                "reference": "381b33ad81395dfac4ad6bfd8a5730869216964d",
                 "shasum": ""
             },
             "require": {
@@ -2442,7 +2442,7 @@
             ],
             "support": {
                 "issues": "https://github.com/T-Regx/T-Regx/issues",
-                "source": "https://github.com/T-Regx/T-Regx/tree/0.39.0"
+                "source": "https://github.com/T-Regx/T-Regx/tree/0.41.0"
             },
             "funding": [
                 {
@@ -2450,7 +2450,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-11-11T15:06:29+00:00"
+            "time": "2022-12-04T13:46:28+00:00"
         },
         {
             "name": "revolt/event-loop",


### PR DESCRIPTION
With T-Regx `0.41.0` comes `/n` modifier, even if you're not on PHP 8.2 (it's backported to every PHP version).

So for example:

```php
Pattern::of('(foo)', 'n'); // works even on PHP 7.1
```