### PR TITLE
Suggestion of T-Regx usage

### DIFF
--- a/src/Tracking/Regex/WorkaroundJ.php
+++ b/src/Tracking/Regex/WorkaroundJ.php
@@ -20,12 +20,8 @@ readonly class WorkaroundJ
 
     public function apply(string $regex): string
     {
-        $i = 0;
-
-        return $this->namedGroup->replace($regex)->callback(function (Detail $match) use (&$i) {
-            ++$i;
-
-            return '(?P<'.$match->group('group_name')->text().'_'.$i.'>';
+        return $this->namedGroup->replace($regex)->callback(function (Detail $match): string {
+            return '(?P<'.$match->get('group_name').'_'.($match->index()+1).'>';
         });
     }
 

--- a/src/Tracking/TextParser.php
+++ b/src/Tracking/TextParser.php
@@ -74,11 +74,11 @@ class TextParser
         $result = [];
 
         foreach ($this->offerStatusPatterns as $statusPattern) {
-            $statusPattern->match($text->getUnused())->forEach(function (Detail $match) use (&$result, $text): void {
+            foreach ($statusPattern->match($text->getUnused()) as $match) {
                 $text->use($match->byteOffset(), $match->byteTail());
 
                 $this->appendDetectedOfferStatuses($match, $result);
-            });
+            }
         }
 
         return $result;

--- a/tests/ByCodeAnalysis/ArtisanFieldsTest.php
+++ b/tests/ByCodeAnalysis/ArtisanFieldsTest.php
@@ -48,13 +48,13 @@ class ArtisanFieldsTest extends TestCase
 
         $fieldsInJson = Fields::public()->asArray();
 
-        $matches->forEach(function (Detail $detail) use (&$fieldsInJson): void {
+        foreach ($matches as $detail) {
             $field = array_shift($fieldsInJson);
 
             static::assertNotNull($field);
             static::assertEquals($field->modelName(), $detail->get('name'));
             static::assertEquals($field->isList(), $detail->matched('is_list'), "{$field->modelName()} should be a list");
-        });
+        }
 
         static::assertEmpty($fieldsInJson);
     }


### PR DESCRIPTION
1. You don't need to store `$i` counter variable, because you can use `$match->index()` method - it returns the ordinal number of the matched occurrence
2. `Matcher` is perfectly suitable to be used in `foreach`, it saves you from passing closed over variables as `&$ref`.

Let me know if you like the changes