### PR TITLE
Update navigation bar

### DIFF
--- a/symfony/assets/scripts/class/Storage.ts
+++ b/symfony/assets/scripts/class/Storage.ts
@@ -36,6 +36,15 @@ export default class Storage {
     this.save(key, value ? "1" : "0", expireSeconds);
   }
 
+  public static remove(key: string): void {
+    try {
+      localStorage.removeItem(this.dataPath(key));
+      localStorage.removeItem(this.expiresPath(key));
+    } catch (e) {
+      console.log("Failed to remove data.", e);
+    }
+  }
+
   protected static get(key: string): string | null {
     try {
       if (this.removeExpired(key)) {
@@ -76,17 +85,11 @@ export default class Storage {
   }
 
   private static removeExpired(key: string): boolean {
-    try {
-      if (!this.hasExpired(key)) {
-        return false;
-      }
-
-      localStorage.removeItem(this.dataPath(key));
-      localStorage.removeItem(this.expiresPath(key));
-    } catch (e) {
-      console.log("Failed to remove data.", e);
+    if (!this.hasExpired(key)) {
+      return false;
     }
 
+    this.remove(key);
     return true;
   }
 

--- a/symfony/assets/scripts/class/Visitor.ts
+++ b/symfony/assets/scripts/class/Visitor.ts
@@ -1,0 +1,37 @@
+import Storage from "./Storage";
+
+const STORAGE_KEY_LAST_VISITED_EVENTS_PAGE = "visitor/lastVisitedEventsPage";
+
+class Visitor {
+  public static get lastVisitedEventsPage(): Date | null {
+    const timestamp = Storage.getString(
+      STORAGE_KEY_LAST_VISITED_EVENTS_PAGE,
+      "",
+    );
+    if (!timestamp) {
+      return null;
+    }
+
+    // Ensure the string is actually a timestamp
+    const date = new Date(timestamp);
+    if (isNaN(date.valueOf())) {
+      return null;
+    }
+
+    return date;
+  }
+
+  public static set lastVisitedEventsPage(date: Date | null) {
+    if (!date) {
+      Storage.remove(STORAGE_KEY_LAST_VISITED_EVENTS_PAGE);
+      return;
+    }
+
+    Storage.saveString(
+      STORAGE_KEY_LAST_VISITED_EVENTS_PAGE,
+      date.toISOString(),
+    );
+  }
+}
+
+export default Visitor;

--- a/symfony/assets/scripts/entry/events.ts
+++ b/symfony/assets/scripts/entry/events.ts
@@ -1,1 +1,6 @@
 import "../../styles/events.scss";
+import Visitor from "../class/Visitor";
+
+jQuery(() => {
+  Visitor.lastVisitedEventsPage = new Date();
+});

--- a/symfony/assets/scripts/entry/general.ts
+++ b/symfony/assets/scripts/entry/general.ts
@@ -1,6 +1,7 @@
 import "bootstrap";
 import * as moment from "moment";
 import AgeAndSfwConfig from "../class/AgeAndSfwConfig";
+import Visitor from "../class/Visitor";
 
 import "../../styles/general.scss";
 import "@fortawesome/fontawesome-free/css/all.min.css";
@@ -31,4 +32,44 @@ jQuery(() => {
     config.setMakerMode(true);
     config.save();
   });
+});
+
+jQuery(() => {
+  const newsNavlink = jQuery("#navlink-news");
+
+  // If we're ON the events page, then never show a badge
+  if (newsNavlink.hasClass("active")) {
+    return;
+  }
+
+  // Validate that we have a timestamp for when events were last updated
+  const timestampStr = newsNavlink.data("latest-event");
+  if (!timestampStr) {
+    return;
+  }
+
+  const timestamp = new Date(timestampStr);
+  if (isNaN(timestamp.valueOf())) {
+    return;
+  }
+
+  // If the user has never visited the events page, don't show the badge.
+  // It would be annoying to show up to a new website for the first time and be
+  // told you have unread notifications.
+  const { lastVisitedEventsPage } = Visitor;
+  if (!lastVisitedEventsPage) {
+    return;
+  }
+
+  // If there've been no new events since they last visited, then don't display
+  // the badge
+  if (lastVisitedEventsPage.valueOf() >= timestamp.valueOf()) {
+    return;
+  }
+
+  // There are new events. Show an unread badge
+  const icon = newsNavlink.find("i");
+  const badge = jQuery(document.createElement("div"));
+  badge.addClass("unread-badge");
+  icon.append(badge);
 });

--- a/symfony/assets/styles/general.scss
+++ b/symfony/assets/styles/general.scss
@@ -35,6 +35,18 @@ html {
 
     i.fas {
       font-size: 1.2rem;
+      position: relative;
+
+      .unread-badge {
+        position: absolute;
+        top: 0;
+        right: 0;
+        transform: translate(50%, -50%);
+        width: 10px;
+        height: 10px;
+        background-color: var(--bs-red);
+        border-radius: 100%;
+      }
     }
   }
 }

--- a/symfony/assets/styles/general.scss
+++ b/symfony/assets/styles/general.scss
@@ -5,6 +5,40 @@ html {
   scroll-behavior: auto !important;
 }
 
+.navbar {
+  .nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+
+    .navlink-label {
+      display: grid;
+      grid-template-columns: 1fr;
+      grid-template-rows: 1fr;
+      grid-template-areas: "cell";
+
+      .spacer,
+      .displayed {
+        grid-area: cell;
+      }
+    }
+
+    &.active .navlink-label .displayed,
+    .navlink-label .spacer {
+      font-weight: bold;
+    }
+
+    .navlink-label .spacer {
+      opacity: 0;
+      user-select: none;
+    }
+
+    i.fas {
+      font-size: 1.2rem;
+    }
+  }
+}
+
 #navbarNav:not(.show) + ul.top-menu-right {
   flex-direction: row;
 

--- a/symfony/assets/styles/general.scss
+++ b/symfony/assets/styles/general.scss
@@ -5,10 +5,6 @@ html {
   scroll-behavior: auto !important;
 }
 
-nav.navbar .navbar-nav .nav-link .always-full-opacity {
-  color: var(--bs-navbar-hover-color);
-}
-
 #navbarNav:not(.show) + ul.top-menu-right {
   flex-direction: row;
 

--- a/symfony/src/Twig/AppExtensions.php
+++ b/symfony/src/Twig/AppExtensions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Twig;
 
 use App\Filtering\FiltersData\Item;
+use App\Repository\EventRepository;
 use App\Service\EnvironmentsService;
 use App\Twig\Utils\HumanFriendly;
 use App\Twig\Utils\SafeFor;
@@ -23,6 +24,7 @@ class AppExtensions extends AbstractExtension
 
     public function __construct(
         private readonly EnvironmentsService $environments,
+        private readonly EventRepository $eventRepository,
     ) {
         $this->friendly = new HumanFriendly();
     }
@@ -54,6 +56,7 @@ class AppExtensions extends AbstractExtension
             new TwigFunction('isDevEnv', $this->isDevEnvFunction(...)),
             new TwigFunction('isDevOrTestEnv', $this->isDevOrTestEnvFunction(...)),
             new TwigFunction('isTestEnv', $this->isTestEnvFunction(...)),
+            new TwigFunction('getLatestEventTimestamp', $this->getLatestEventTimestamp(...)),
         ];
     }
 
@@ -70,6 +73,16 @@ class AppExtensions extends AbstractExtension
     public function isTestEnvFunction(): bool
     {
         return $this->environments->isTest();
+    }
+
+    public function getLatestEventTimestamp(): ?string
+    {
+        $timestamp = $this->eventRepository->getLatestEventTimestamp();
+        if (null === $timestamp) {
+            return null;
+        }
+
+        return $timestamp->format("Y-m-d H:i:s P");
     }
 
     /**

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -7,10 +7,8 @@
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 {% include '_menu_item.html.twig' with {'name': 'main', 'fa_icon': 'home', 'label': 'Home' } %}
-                {% include '_menu_item.html.twig' with {'name': 'iu_form_step_start', 'fa_icon': 'user-plus', 'label': 'Join/update' } %}
-                {% include '_menu_item.html.twig' with {'name': 'info', 'fa_icon': 'question-circle', 'label': 'Information' } %}
-                {% include '_menu_item.html.twig' with {'name': 'maker_ids', 'fa_icon': 'id-badge', 'label': 'Maker IDs' } %}
-                {% include '_menu_item.html.twig' with {'name': 'events', 'fa_icon': 'history', 'label': 'Updates' } %}
+                {% include '_menu_item.html.twig' with {'name': 'info', 'fa_icon': 'circle-info', 'label': 'About' } %}
+                {% include '_menu_item.html.twig' with {'name': 'events', 'fa_icon': 'newspaper', 'label': 'News' } %}
                 {% if isDevEnv() %}
                     {% include '_menu_item.html.twig' with {'name': 'mx_artisan_new', 'fa_icon': 'plus', 'label': 'Maker' } %}
                     {% include '_menu_item.html.twig' with {'name': 'mx_event_new', 'fa_icon': 'plus', 'label': 'Event' } %}
@@ -22,8 +20,9 @@
         </div>
 
         <ul class="navbar-nav d-flex top-menu-right">
-            {% include '_menu_item.html.twig' with {'name': 'contact', 'fa_icon': 'envelope', 'label': 'Contact' } %}
+            {% include '_menu_item.html.twig' with {'name': 'iu_form_step_start', 'fa_icon': 'user-gear', 'label': 'Fursuit Makers' } %}
             {% include '_menu_item.html.twig' with {'name': 'donate',  'fa_icon': 'circle-dollar-to-slot', 'label': 'Donate' } %}
+            {% include '_menu_item.html.twig' with {'name': 'contact', 'fa_icon': 'envelope', 'label': 'Contact' } %}
         </ul>
     </div>
 </nav>

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -8,7 +8,15 @@
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 {% include '_menu_item.html.twig' with {'name': 'main', 'fa_icon': 'home', 'label': 'Home' } %}
                 {% include '_menu_item.html.twig' with {'name': 'info', 'fa_icon': 'circle-info', 'label': 'About' } %}
-                {% include '_menu_item.html.twig' with {'name': 'events', 'fa_icon': 'newspaper', 'label': 'News' } %}
+                {% include '_menu_item.html.twig' with {
+                    'id': 'navlink-news',
+                    'data_attrs': {
+                        'latest-event': getLatestEventTimestamp()
+                    },
+                    'name': 'events',
+                    'fa_icon': 'newspaper',
+                    'label': 'News'
+                } %}
                 {% if isDevEnv() %}
                     {% include '_menu_item.html.twig' with {'name': 'mx_artisan_new', 'fa_icon': 'plus', 'label': 'Maker' } %}
                     {% include '_menu_item.html.twig' with {'name': 'mx_event_new', 'fa_icon': 'plus', 'label': 'Event' } %}

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -6,24 +6,24 @@
 
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                {% include '_menu_item.html.twig' with {'name': 'main', 'pretty_name': '<i class="fas fa-home"></i> Home' } %}
-                {% include '_menu_item.html.twig' with {'name': 'iu_form_step_start', 'pretty_name': '<i class="fas fa-user-plus"></i> Join/update' } %}
-                {% include '_menu_item.html.twig' with {'name': 'info', 'pretty_name': '<i class="fas fa-question-circle"></i> Information' } %}
-                {% include '_menu_item.html.twig' with {'name': 'maker_ids', 'pretty_name': '<i class="fas fa-id-badge"></i> Maker IDs' } %}
-                {% include '_menu_item.html.twig' with {'name': 'events', 'pretty_name': '<i class="fas fa-history"></i> Updates' } %}
+                {% include '_menu_item.html.twig' with {'name': 'main', 'fa_icon': 'home', 'label': 'Home' } %}
+                {% include '_menu_item.html.twig' with {'name': 'iu_form_step_start', 'fa_icon': 'user-plus', 'label': 'Join/update' } %}
+                {% include '_menu_item.html.twig' with {'name': 'info', 'fa_icon': 'question-circle', 'label': 'Information' } %}
+                {% include '_menu_item.html.twig' with {'name': 'maker_ids', 'fa_icon': 'id-badge', 'label': 'Maker IDs' } %}
+                {% include '_menu_item.html.twig' with {'name': 'events', 'fa_icon': 'history', 'label': 'Updates' } %}
                 {% if isDevEnv() %}
-                    {% include '_menu_item.html.twig' with {'name': 'mx_artisan_new', 'pretty_name': '<i class="fas fa-plus"></i> Maker' } %}
-                    {% include '_menu_item.html.twig' with {'name': 'mx_event_new', 'pretty_name': '<i class="fas fa-plus"></i> Event' } %}
-                    {% include '_menu_item.html.twig' with {'name': 'mx_artisan_urls', 'pretty_name': '<i class="fas fa-link"></i> URLs' } %}
-                    {% include '_menu_item.html.twig' with {'name': 'mx_query', 'pretty_name': '<i class="fas fa-filter"></i> Query' } %}
-                    {% include '_menu_item.html.twig' with {'name': 'mx_submissions', 'pretty_name': '<i class="fa-solid fa-file-lines"></i> Submissions' } %}
+                    {% include '_menu_item.html.twig' with {'name': 'mx_artisan_new', 'fa_icon': 'plus', 'label': 'Maker' } %}
+                    {% include '_menu_item.html.twig' with {'name': 'mx_event_new', 'fa_icon': 'plus', 'label': 'Event' } %}
+                    {% include '_menu_item.html.twig' with {'name': 'mx_artisan_urls', 'fa_icon': 'link', 'label': 'URLs' } %}
+                    {% include '_menu_item.html.twig' with {'name': 'mx_query', 'fa_icon': 'filter', 'label': 'Query' } %}
+                    {% include '_menu_item.html.twig' with {'name': 'mx_submissions', 'fa_icon': 'file-lines', 'label': 'Submissions' } %}
                 {% endif %}
             </ul>
         </div>
 
         <ul class="navbar-nav d-flex top-menu-right">
-            {% include '_menu_item.html.twig' with {'name': 'contact', 'pretty_name': '<i class="fa-solid fa-envelope"></i> Contact' } %}
-            {% include '_menu_item.html.twig' with {'name': 'donate', 'pretty_name': '<span class="always-full-opacity">🥌</span>️ Donate' } %}
+            {% include '_menu_item.html.twig' with {'name': 'contact', 'fa_icon': 'envelope', 'label': 'Contact' } %}
+            {% include '_menu_item.html.twig' with {'name': 'donate',  'fa_icon': 'circle-dollar-to-slot', 'label': 'Donate' } %}
         </ul>
     </div>
 </nav>

--- a/symfony/templates/_menu_item.html.twig
+++ b/symfony/templates/_menu_item.html.twig
@@ -1,5 +1,5 @@
 {% set is_active = app.request.attributes.get('_route') == name %}
 
 <li class="nav-item">
-    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}">{{ pretty_name|raw }}</a>
+    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}"><i class="fas fa-{{ fa_icon }}"></i> {{ label }}</a>
 </li>

--- a/symfony/templates/_menu_item.html.twig
+++ b/symfony/templates/_menu_item.html.twig
@@ -1,5 +1,11 @@
 {% set is_active = app.request.attributes.get('_route') == name %}
 
 <li class="nav-item">
-    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}"><i class="fas fa-{{ fa_icon }}"></i> {{ label }}</a>
+    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}">
+        <i class="fas fa-{{ fa_icon }}"></i>
+        <span class="navlink-label">
+          <div class="spacer">{{ label }}</div>
+          <div class="displayed">{{ label }}</div>
+        </span>
+    </a>
 </li>

--- a/symfony/templates/_menu_item.html.twig
+++ b/symfony/templates/_menu_item.html.twig
@@ -1,7 +1,15 @@
 {% set is_active = app.request.attributes.get('_route') == name %}
 
 <li class="nav-item">
-    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}">
+    <a
+        {% if id is defined %}id="{{id}}"{% endif %}
+        {% if data_attrs is defined %}
+            {{ data_attrs | map((value, key) => "data-#{key}=\"#{value}\"") | join(",") | raw }}
+        {% endif %}
+        class="nav-link {% if is_active %}active{% endif %}"
+        {% if is_active %}aria-current="page"{% endif %}
+        href="{{ path(name) }}"
+    >
         <i class="fas fa-{{ fa_icon }}"></i>
         <span class="navlink-label">
           <div class="spacer">{{ label }}</div>


### PR DESCRIPTION
I focused on a couple QoL improvements for the navigation bar:

**Cleaned up links.** I've simplified the names and icons for the navbar
* "Information" → "About"
* "Updates" → "News"
    * The original name "Updates" felt more like "changelog" — you'd go to that page for software update information
    * "News" felt like it better conveyed that the page wasn't about software, it was about events/changes/updates in the community
* "+Join/Update" → "Fursuit Makers"
    * I did this to clarify that you can't sign up for a new user account with getfursu.it, it's just for fursuit makers

I also reorganized the links. Following web design principles that expect left → right, I put the links that are relevant for all users on the left. Links that are less universal are on the right.

I also updated the icons to try and improve clarity/use more familiar iconography.

**Removed "Maker IDs" link.** There's a link to it from the about page. Having it in the navbar competed for user's attention. I also think future UI updates can better highlight Maker IDs within the app, so there wouldn't be a significant need for a dedicated page.

**Made active page more visible.** The label is bold to show you which page you're on

**Unread events badge.** If a new event has been created since you last visited the events page, it will display a badge on the icon. The badge goes away when you visit the page.

## Screenshots

**Before:**
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/3be9da17-ae6e-435d-b14d-c90857fd2073">

**After:**
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/4674ed25-9dde-4145-bc8b-8f6d79e5bbec">
<img width="1123" alt="image" src="https://github.com/user-attachments/assets/347d9570-24a6-4140-98b2-fb2517b01102">
