### PR TITLE
Create navbar layout engine

### DIFF
--- a/symfony/assets/scripts/class/navbar/DesktopLayoutStrategy.ts
+++ b/symfony/assets/scripts/class/navbar/DesktopLayoutStrategy.ts
@@ -1,0 +1,83 @@
+import LayoutStrategy, { LayoutStrategyEvent } from "./LayoutStrategy";
+import { DisconnectFn } from "./NavbarMenuButton";
+
+const ITEM_GAP_PX = 12;
+
+class DesktopLayoutStrategy implements LayoutStrategy {
+  private disconnectOverflowMenuButton: DisconnectFn | null = null;
+
+  public init({
+    menu,
+    mobileDrawerButton,
+    overflowMenuButton,
+  }: LayoutStrategyEvent): void {
+    // The drawer menu button will never be visible in this layout
+    mobileDrawerButton.setVisible(false);
+
+    // Connect the menu to the overflow button
+    this.disconnectOverflowMenuButton = overflowMenuButton.connect(menu);
+  }
+
+  public destroy(): void {
+    // Disconnect the menu from the overflow button
+    this.disconnectOverflowMenuButton?.();
+  }
+
+  public update({
+    contentWidth,
+    prioritizedLinks,
+    separator,
+    overflowMenuButton,
+  }: LayoutStrategyEvent): void {
+    const { width: overflowMenuButtonWidth } = overflowMenuButton;
+
+    // Figure out which items we have room for
+    let remainingWidth = contentWidth;
+    let visibleIndex = 0;
+    while (remainingWidth > 0 && visibleIndex < prioritizedLinks.length) {
+      // Figure out how much space is reserved on the navbar
+      const reservedSize =
+        visibleIndex === prioritizedLinks.length - 1
+          ? // If this is the final link, then it means that if we show this link
+            // we will also be making the separator between left and right sides
+            // visible -- that is, we have 2 DOM nodes becoming visible, not just 1,
+            // which means we have additional CSS `gap` to consider when measuring
+            ITEM_GAP_PX
+          : // If we don't know yet that we're able to fit ALL of the items on the navbar,
+            // we'll make sure to reserve space for the overflow button. ONLY IF we're
+            // looking at the final item (which, if it fits, means we don't need the
+            // overflow button) do we omit the overflow button.
+            overflowMenuButtonWidth + ITEM_GAP_PX;
+
+      // If we can't fit the item, then we're finished
+      if (
+        remainingWidth <
+        prioritizedLinks[visibleIndex].width + reservedSize
+      ) {
+        break;
+      }
+
+      // Include this link and check the next one
+      remainingWidth -= prioritizedLinks[visibleIndex].width;
+      remainingWidth -= ITEM_GAP_PX;
+      visibleIndex++;
+    }
+
+    // Set links to be visible or invisible
+    prioritizedLinks.forEach((link, index): void => {
+      link.setVisible(index < visibleIndex);
+    });
+
+    // If all of our items are visible, then we have room to separate them into
+    // different sides of the navbar. But if we're space constrained and we're
+    // not able to display all of our items, we don't have enough room to separate
+    // them out into different sides
+    separator.setVisible(visibleIndex === prioritizedLinks.length);
+
+    // If any navbar items aren't visible, then we'll show the overflow menu
+    // button
+    overflowMenuButton.setVisible(visibleIndex < prioritizedLinks.length);
+  }
+}
+
+export default DesktopLayoutStrategy;

--- a/symfony/assets/scripts/class/navbar/LayoutStrategy.ts
+++ b/symfony/assets/scripts/class/navbar/LayoutStrategy.ts
@@ -1,0 +1,47 @@
+import type NavbarElement from "./NavbarElement";
+import type NavbarLink from "./NavbarLink";
+import NavbarMenuButton from "./NavbarMenuButton";
+import type Menu from "./Menu";
+
+export interface LayoutStrategyEvent {
+  contentWidth: number;
+  prioritizedLinks: readonly NavbarLink[];
+  menu: Menu;
+  overflowMenuButton: NavbarMenuButton;
+  mobileDrawerButton: NavbarMenuButton;
+  separator: NavbarElement<HTMLDivElement>;
+}
+
+interface LayoutStrategy {
+  /**
+   * Called when the navbar transitions to using this layout strategy.
+   *
+   * @guarantee Once called, this will not be called again on this
+   * instance (future usages of this strategy will be new instances).
+   * @guarantee Will always be called before {@link LayoutStrategy.update}.
+   */
+  init(event: LayoutStrategyEvent): void;
+
+  /**
+   * Called every time the width of the navbar changes.
+   *
+   * NOTE: During the initial frame that transitions to this strategy, this
+   * will be called immediately after {@link LayoutStrategy.init}
+   *
+   * @guarantee Will always be called after {@link LayoutStrategy.init} has
+   * been called.
+   * @guarantee Will not be called after {@link LayoutStrategy.destroy} has
+   * been called.
+   */
+  update(event: LayoutStrategyEvent): void;
+
+  /**
+   * Called when the navbar is transitioning to a new layout strategy.
+   *
+   * @guarantee Once called, this will not be called again on this
+   * instance (future usages of this strategy will be new instances).
+   */
+  destroy(event: LayoutStrategyEvent): void;
+}
+
+export default LayoutStrategy;

--- a/symfony/assets/scripts/class/navbar/Menu.ts
+++ b/symfony/assets/scripts/class/navbar/Menu.ts
@@ -1,4 +1,7 @@
 type MenuListener = (isOpen: boolean) => void;
+export type UnsubscribeFn = () => void;
+
+type MenuMode = "dropdown" | "drawer";
 
 export interface MenuItem {
   setVisible(visible: boolean): void;
@@ -18,6 +21,18 @@ class Menu {
 
   public get isOpen(): boolean {
     return this.node.classList.contains("visible");
+  }
+
+  public get mode(): MenuMode {
+    if (this.node.classList.contains("nav-dropdown-menu")) {
+      return "dropdown";
+    }
+
+    if (this.node.classList.contains("nav-drawer-menu")) {
+      return "drawer";
+    }
+
+    throw new Error("Unknown current nav menu mode");
   }
 
   public show(): void {
@@ -42,8 +57,20 @@ class Menu {
     this.listeners.forEach((listener) => listener(false));
   }
 
-  public subscribe(listener: MenuListener): void {
+  public subscribe(listener: MenuListener): UnsubscribeFn {
     this.listeners.add(listener);
+    return (): void => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public setMode(mode: MenuMode): void {
+    if (this.mode === mode) {
+      return;
+    }
+
+    this.node.classList.toggle("nav-dropdown-menu", mode === "dropdown");
+    this.node.classList.toggle("nav-drawer-menu", mode === "drawer");
   }
 
   public cloneAppend(origItem: HTMLElement): MenuItem {

--- a/symfony/assets/scripts/class/navbar/Menu.ts
+++ b/symfony/assets/scripts/class/navbar/Menu.ts
@@ -1,0 +1,60 @@
+type MenuListener = (isOpen: boolean) => void;
+
+export interface MenuItem {
+  setVisible(visible: boolean): void;
+}
+
+class Menu {
+  private readonly listeners = new Set<MenuListener>();
+
+  public constructor(
+    private readonly node: HTMLDivElement,
+    private readonly backdropNode: HTMLDivElement,
+  ) {
+    backdropNode.addEventListener("click", (): void => {
+      this.hide();
+    });
+  }
+
+  public get isOpen(): boolean {
+    return this.node.classList.contains("visible");
+  }
+
+  public show(): void {
+    if (this.isOpen) {
+      return;
+    }
+
+    this.node.classList.toggle("visible", true);
+    this.backdropNode.classList.toggle("visible", true);
+    document.body.classList.toggle("nav-menu-open", true);
+    this.listeners.forEach((listener) => listener(true));
+  }
+
+  public hide(): void {
+    if (!this.isOpen) {
+      return;
+    }
+
+    document.body.classList.toggle("nav-menu-open", false);
+    this.backdropNode.classList.toggle("visible", false);
+    this.node.classList.toggle("visible", false);
+    this.listeners.forEach((listener) => listener(false));
+  }
+
+  public subscribe(listener: MenuListener): void {
+    this.listeners.add(listener);
+  }
+
+  public cloneAppend(origItem: HTMLElement): MenuItem {
+    const clone = origItem.cloneNode(true) as HTMLElement;
+    this.node.appendChild(clone);
+    return {
+      setVisible: (visible): void => {
+        clone.classList.toggle("hidden", !visible);
+      },
+    };
+  }
+}
+
+export default Menu;

--- a/symfony/assets/scripts/class/navbar/MobileLayoutStrategy.ts
+++ b/symfony/assets/scripts/class/navbar/MobileLayoutStrategy.ts
@@ -1,0 +1,47 @@
+import LayoutStrategy, { LayoutStrategyEvent } from "./LayoutStrategy";
+import { DisconnectFn } from "./NavbarMenuButton";
+
+class MobileLayoutStrategy implements LayoutStrategy {
+  private disconnectDrawerMenuButton: DisconnectFn | null = null;
+
+  public init({
+    menu,
+    mobileDrawerButton,
+    overflowMenuButton,
+    prioritizedLinks,
+    separator,
+  }: LayoutStrategyEvent): void {
+    // Make all of the links, the separator, and the overflow menu button are
+    // all invisible
+    separator.setVisible(false);
+    prioritizedLinks.forEach((link) => link.setVisible(false));
+    overflowMenuButton.setVisible(false);
+
+    // Connect the menu to the drawer menu button, and make sure it's visible
+    this.disconnectDrawerMenuButton = mobileDrawerButton.connect(menu);
+    mobileDrawerButton.setVisible(true);
+
+    // If the overflow menu is already visible, let's close it for now
+    // so we can reset things
+    menu.hide();
+
+    // Set the overflow menu into drawer mode
+    menu.setMode("drawer");
+  }
+
+  public destroy({ menu }: LayoutStrategyEvent): void {
+    // If the overflow menu is already visible, let's close it to reset
+    // it
+    menu.hide();
+
+    // Disconnect the menu from the drawer button
+    this.disconnectDrawerMenuButton?.();
+
+    // Set the overflow menu back to dropdown mode (default)
+    menu.setMode("dropdown");
+  }
+
+  public update(): void {}
+}
+
+export default MobileLayoutStrategy;

--- a/symfony/assets/scripts/class/navbar/Navbar.ts
+++ b/symfony/assets/scripts/class/navbar/Navbar.ts
@@ -126,7 +126,7 @@ class Navbar {
   private activeLayoutStrategy: LayoutStrategy | null = null;
 
   private constructor(
-    main: HTMLDivElement,
+    private readonly main: HTMLDivElement,
     menuNode: HTMLDivElement,
     menuBackdropNode: HTMLDivElement,
   ) {
@@ -181,6 +181,10 @@ class Navbar {
 
     // Have the guaranteed now-correct active strategy run its update
     this.activeLayoutStrategy.update(event);
+
+    // If we haven't marked the main DOM node as being initialized already, do
+    // so now that we've for-sure run our update at least once
+    this.main.classList.add("initialized"); // Only appends if not present
   }
 }
 

--- a/symfony/assets/scripts/class/navbar/Navbar.ts
+++ b/symfony/assets/scripts/class/navbar/Navbar.ts
@@ -1,0 +1,131 @@
+import NavbarElement from "./NavbarElement";
+import NavbarLink, { NavbarLinkPriority } from "./NavbarLink";
+
+const ITEM_GAP_PX = 12;
+
+const PRIORITY_NUMBER: Record<NavbarLinkPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+function parseMainChildren(children: NodeListOf<ChildNode>): {
+  links: readonly HTMLAnchorElement[];
+  separator: HTMLDivElement;
+} {
+  const links: HTMLAnchorElement[] = [];
+  let separator: HTMLDivElement | null = null;
+  for (const child of children) {
+    if (child instanceof Text && !child.textContent?.trim()) {
+      continue;
+    }
+
+    if (
+      child instanceof HTMLDivElement &&
+      child.className === "nav-separator"
+    ) {
+      separator = child;
+      continue;
+    }
+
+    if (
+      child instanceof HTMLAnchorElement &&
+      child.classList.contains("nav-link")
+    ) {
+      links.push(child);
+      continue;
+    }
+
+    // Prefer throwing an error over error supression. The reason for this is
+    // that our algorithm expects to know how to calculate the size/layout of
+    // the navbar. If we have extra elements in there we don't know about, our
+    // calculation will be wrong and it'll be a bug.
+    // We should always need to update our code here as we add/change items in
+    // the navbar DOM.
+    throw new Error("Unexpected child of navbar element");
+  }
+
+  if (!separator) {
+    throw new Error("Could not find navbar separator");
+  }
+
+  return { separator, links };
+}
+
+class Navbar {
+  public static init(): Navbar {
+    const root = document.getElementById("navbar");
+    if (!root) {
+      throw new Error("No navbar detected in DOM");
+    }
+
+    const main = root.querySelector("div.navbar-main");
+    if (!(main instanceof HTMLDivElement)) {
+      throw new Error("Cannot find navbar nav container");
+    }
+
+    return new Navbar(main);
+  }
+
+  private readonly resizeObserver: ResizeObserver;
+  private readonly separator: NavbarElement<HTMLDivElement>;
+  private readonly prioritizedLinks: readonly NavbarLink[];
+
+  private constructor(main: HTMLDivElement) {
+    const { separator, links } = parseMainChildren(main.childNodes);
+    this.separator = new NavbarElement(separator);
+    this.prioritizedLinks = links
+      .map((node) => new NavbarLink(node))
+      .sort(
+        (a, b) => PRIORITY_NUMBER[a.priority] - PRIORITY_NUMBER[b.priority],
+      );
+
+    this.resizeObserver = new ResizeObserver(([entry]): void =>
+      this.layout(entry.contentRect.width),
+    );
+    this.resizeObserver.observe(main);
+  }
+
+  private layout(contentWidth: number): void {
+    // Figure out which items we have room for
+    let remainingWidth = contentWidth;
+    let visibleIndex = 0;
+    while (remainingWidth > 0 && visibleIndex < this.prioritizedLinks.length) {
+      // Figure out how much space is reserved on the navbar
+      const reservedSize =
+        visibleIndex === this.prioritizedLinks.length - 1
+          ? // If this is the final link, then it means that if we show this link
+            // we will also be making the separator between left and right sides
+            // visible -- that is, we have 2 DOM nodes becoming visible, not just 1,
+            // which means we have additional CSS `gap` to consider when measuring
+            ITEM_GAP_PX
+          : 0;
+
+      // If we can't fit the item, then we're finished
+      if (
+        remainingWidth <
+        this.prioritizedLinks[visibleIndex].width + reservedSize
+      ) {
+        break;
+      }
+
+      // Include this link and check the next one
+      remainingWidth -= this.prioritizedLinks[visibleIndex].width;
+      remainingWidth -= ITEM_GAP_PX;
+      visibleIndex++;
+    }
+
+    // Set links to be visible or invisible
+    this.prioritizedLinks.forEach((link, index): void => {
+      link.setVisible(index < visibleIndex);
+    });
+
+    // If all of our items are visible, then we have room to separate them into
+    // different sides of the navbar. But if we're space constrained and we're
+    // not able to display all of our items, we don't have enough room to separate
+    // them out into different sides
+    this.separator.setVisible(visibleIndex === this.prioritizedLinks.length);
+  }
+}
+
+export default Navbar;

--- a/symfony/assets/scripts/class/navbar/Navbar.ts
+++ b/symfony/assets/scripts/class/navbar/Navbar.ts
@@ -18,7 +18,7 @@ const PRIORITY_NUMBER: Record<NavbarLinkPriority, number> = {
  * Number was chosen to target conventional mobile devices as being "mobile" but
  * is otherwise arbitrary and can be changed as needed.
  */
-const MOBILE_LAYOUT_BREAKPOINT_PX = 500;
+const MOBILE_LAYOUT_BREAKPOINT_PX = 576;
 
 function parseMainChildren(children: NodeListOf<ChildNode>): {
   links: readonly HTMLAnchorElement[];

--- a/symfony/assets/scripts/class/navbar/Navbar.ts
+++ b/symfony/assets/scripts/class/navbar/Navbar.ts
@@ -1,9 +1,10 @@
+import DesktopLayoutStrategy from "./DesktopLayoutStrategy";
+import LayoutStrategy, { LayoutStrategyEvent } from "./LayoutStrategy";
+import MobileLayoutStrategy from "./MobileLayoutStrategy";
 import NavbarElement from "./NavbarElement";
 import NavbarLink, { NavbarLinkPriority } from "./NavbarLink";
-import NavbarOverflowMenuButton from "./NavbarOverflowMenuButton";
+import NavbarMenuButton from "./NavbarMenuButton";
 import Menu from "./Menu";
-
-const ITEM_GAP_PX = 12;
 
 const PRIORITY_NUMBER: Record<NavbarLinkPriority, number> = {
   high: 0,
@@ -11,14 +12,24 @@ const PRIORITY_NUMBER: Record<NavbarLinkPriority, number> = {
   low: 2,
 };
 
+/**
+ * Below this number, the navbar will display in the mobile version. Above this
+ * number, the navbar will display in the desktop version.
+ * Number was chosen to target conventional mobile devices as being "mobile" but
+ * is otherwise arbitrary and can be changed as needed.
+ */
+const MOBILE_LAYOUT_BREAKPOINT_PX = 500;
+
 function parseMainChildren(children: NodeListOf<ChildNode>): {
   links: readonly HTMLAnchorElement[];
   separator: HTMLDivElement;
   overflowMenuButton: HTMLButtonElement;
+  mobileDrawerButton: HTMLButtonElement;
 } {
   const links: HTMLAnchorElement[] = [];
   let separator: HTMLDivElement | null = null;
   let overflowMenuButton: HTMLButtonElement | null = null;
+  let mobileDrawerButton: HTMLButtonElement | null = null;
   for (const child of children) {
     if (child instanceof Text && !child.textContent?.trim()) {
       continue;
@@ -48,6 +59,14 @@ function parseMainChildren(children: NodeListOf<ChildNode>): {
       continue;
     }
 
+    if (
+      child instanceof HTMLButtonElement &&
+      child.className === "nav-mobile-drawer-button"
+    ) {
+      mobileDrawerButton = child;
+      continue;
+    }
+
     // Prefer throwing an error over error supression. The reason for this is
     // that our algorithm expects to know how to calculate the size/layout of
     // the navbar. If we have extra elements in there we don't know about, our
@@ -65,7 +84,11 @@ function parseMainChildren(children: NodeListOf<ChildNode>): {
     throw new Error("Could not find navbar overflow menu button");
   }
 
-  return { separator, links, overflowMenuButton };
+  if (!mobileDrawerButton) {
+    throw new Error("Could not find navbar mobile drawer button");
+  }
+
+  return { separator, links, overflowMenuButton, mobileDrawerButton };
 }
 
 class Navbar {
@@ -80,7 +103,8 @@ class Navbar {
       throw new Error("Cannot find navbar nav container");
     }
 
-    const menuNode = root.querySelector("div.nav-menu");
+    // Menu starts out in "dropdown" mode when rendered in the HTML
+    const menuNode = root.querySelector("div.nav-dropdown-menu");
     if (!(menuNode instanceof HTMLDivElement)) {
       throw new Error("Cannot find navbar menu node");
     }
@@ -96,20 +120,21 @@ class Navbar {
   private readonly resizeObserver: ResizeObserver;
   private readonly separator: NavbarElement<HTMLDivElement>;
   private readonly prioritizedLinks: readonly NavbarLink[];
-  private readonly overflowMenuButton: NavbarOverflowMenuButton;
+  private readonly overflowMenuButton: NavbarMenuButton;
+  private readonly mobileDrawerButton: NavbarMenuButton;
   private readonly menu: Menu;
+  private activeLayoutStrategy: LayoutStrategy | null = null;
 
   private constructor(
     main: HTMLDivElement,
     menuNode: HTMLDivElement,
     menuBackdropNode: HTMLDivElement,
   ) {
-    const { separator, links, overflowMenuButton } = parseMainChildren(
-      main.childNodes,
-    );
+    const { separator, links, overflowMenuButton, mobileDrawerButton } =
+      parseMainChildren(main.childNodes);
     this.menu = new Menu(menuNode, menuBackdropNode);
-    this.overflowMenuButton = new NavbarOverflowMenuButton(overflowMenuButton);
-    this.overflowMenuButton.connect(this.menu);
+    this.overflowMenuButton = new NavbarMenuButton(overflowMenuButton);
+    this.mobileDrawerButton = new NavbarMenuButton(mobileDrawerButton);
 
     this.separator = new NavbarElement(separator);
     this.prioritizedLinks = links
@@ -119,62 +144,43 @@ class Navbar {
       );
 
     this.resizeObserver = new ResizeObserver(([entry]): void =>
-      this.layout(entry.contentRect.width),
+      this.layout(entry.target.clientWidth, entry.contentRect.width),
     );
     this.resizeObserver.observe(main);
   }
 
-  private layout(contentWidth: number): void {
-    const { width: overflowMenuButtonWidth } = this.overflowMenuButton;
+  private layout(clientWidth: number, contentWidth: number): void {
+    const event: LayoutStrategyEvent = {
+      contentWidth,
+      prioritizedLinks: this.prioritizedLinks,
+      separator: this.separator,
+      menu: this.menu,
+      overflowMenuButton: this.overflowMenuButton,
+      mobileDrawerButton: this.mobileDrawerButton,
+    };
 
-    // Figure out which items we have room for
-    let remainingWidth = contentWidth;
-    let visibleIndex = 0;
-    while (remainingWidth > 0 && visibleIndex < this.prioritizedLinks.length) {
-      // Figure out how much space is reserved on the navbar
-      const reservedSize =
-        visibleIndex === this.prioritizedLinks.length - 1
-          ? // If this is the final link, then it means that if we show this link
-            // we will also be making the separator between left and right sides
-            // visible -- that is, we have 2 DOM nodes becoming visible, not just 1,
-            // which means we have additional CSS `gap` to consider when measuring
-            ITEM_GAP_PX
-          : // If we don't know yet that we're able to fit ALL of the items on the navbar,
-            // we'll make sure to reserve space for the overflow button. ONLY IF we're
-            // looking at the final item (which, if it fits, means we don't need the
-            // overflow button) do we omit the overflow button.
-            overflowMenuButtonWidth + ITEM_GAP_PX;
+    // Figure out which layout strategy we *should* be using.
+    // We want to use the `clientWidth` (total bounding box width) rather than
+    // `contentWidth` (usable space inside node) since we want to include padding
+    // and such (breakpoints are commonly measured in total width).
+    const TargetLayoutStrategy =
+      clientWidth <= MOBILE_LAYOUT_BREAKPOINT_PX
+        ? MobileLayoutStrategy
+        : DesktopLayoutStrategy;
 
-      // If we can't fit the item, then we're finished
-      if (
-        remainingWidth <
-        this.prioritizedLinks[visibleIndex].width + reservedSize
-      ) {
-        break;
-      }
-
-      // Include this link and check the next one
-      remainingWidth -= this.prioritizedLinks[visibleIndex].width;
-      remainingWidth -= ITEM_GAP_PX;
-      visibleIndex++;
+    // If that isn't the strategy that we're currently using, let's transition
+    // to it
+    if (
+      this.activeLayoutStrategy === null ||
+      !(this.activeLayoutStrategy instanceof TargetLayoutStrategy)
+    ) {
+      this.activeLayoutStrategy?.destroy(event);
+      this.activeLayoutStrategy = new TargetLayoutStrategy();
+      this.activeLayoutStrategy.init(event);
     }
 
-    // Set links to be visible or invisible
-    this.prioritizedLinks.forEach((link, index): void => {
-      link.setVisible(index < visibleIndex);
-    });
-
-    // If all of our items are visible, then we have room to separate them into
-    // different sides of the navbar. But if we're space constrained and we're
-    // not able to display all of our items, we don't have enough room to separate
-    // them out into different sides
-    this.separator.setVisible(visibleIndex === this.prioritizedLinks.length);
-
-    // If any navbar items aren't visible, then we'll show the overflow menu
-    // button
-    this.overflowMenuButton.setVisible(
-      visibleIndex < this.prioritizedLinks.length,
-    );
+    // Have the guaranteed now-correct active strategy run its update
+    this.activeLayoutStrategy.update(event);
   }
 }
 

--- a/symfony/assets/scripts/class/navbar/NavbarElement.ts
+++ b/symfony/assets/scripts/class/navbar/NavbarElement.ts
@@ -1,0 +1,9 @@
+class NavbarElement<TNode extends HTMLElement> {
+  public constructor(protected readonly node: TNode) {}
+
+  public setVisible(visible: boolean): void {
+    this.node.classList.toggle("hidden", !visible);
+  }
+}
+
+export default NavbarElement;

--- a/symfony/assets/scripts/class/navbar/NavbarLink.ts
+++ b/symfony/assets/scripts/class/navbar/NavbarLink.ts
@@ -1,0 +1,32 @@
+import NavbarElement from "./NavbarElement";
+
+export type NavbarLinkPriority = "high" | "medium" | "low";
+
+function getPriority(str: string | undefined): NavbarLinkPriority {
+  const lowered = str?.toLowerCase();
+  switch (lowered) {
+    case "high":
+    case "medium":
+    case "low": {
+      return lowered;
+    }
+    default: {
+      return "medium";
+    }
+  }
+}
+
+class NavbarLink extends NavbarElement<HTMLAnchorElement> {
+  public readonly priority: NavbarLinkPriority;
+
+  public constructor(node: HTMLAnchorElement) {
+    super(node);
+    this.priority = getPriority(node.dataset["priority"]);
+  }
+
+  public get width(): number {
+    return this.node.clientWidth;
+  }
+}
+
+export default NavbarLink;

--- a/symfony/assets/scripts/class/navbar/NavbarLink.ts
+++ b/symfony/assets/scripts/class/navbar/NavbarLink.ts
@@ -1,4 +1,5 @@
 import NavbarElement from "./NavbarElement";
+import type { MenuItem } from "./Menu";
 
 export type NavbarLinkPriority = "high" | "medium" | "low";
 
@@ -19,13 +20,21 @@ function getPriority(str: string | undefined): NavbarLinkPriority {
 class NavbarLink extends NavbarElement<HTMLAnchorElement> {
   public readonly priority: NavbarLinkPriority;
 
-  public constructor(node: HTMLAnchorElement) {
+  public constructor(
+    node: HTMLAnchorElement,
+    private readonly menuItem: MenuItem,
+  ) {
     super(node);
     this.priority = getPriority(node.dataset["priority"]);
   }
 
   public get width(): number {
     return this.node.clientWidth;
+  }
+
+  public setVisible(visible: boolean): void {
+    super.setVisible(visible);
+    this.menuItem.setVisible(!visible);
   }
 }
 

--- a/symfony/assets/scripts/class/navbar/NavbarMenuButton.ts
+++ b/symfony/assets/scripts/class/navbar/NavbarMenuButton.ts
@@ -1,0 +1,68 @@
+import NavbarElement from "./NavbarElement";
+import type Menu from "./Menu";
+
+export type DisconnectFn = () => void;
+
+class NavbarMenuButton extends NavbarElement<HTMLButtonElement> {
+  private menu: Menu | null = null;
+
+  public constructor(node: HTMLButtonElement) {
+    super(node);
+  }
+
+  public get width(): number {
+    return this.node.clientWidth;
+  }
+
+  public setVisible(visible: boolean): void {
+    if (!this.menu && visible) {
+      console.warn(
+        "Cannot make a menu button visible if it isn't bound to the menu",
+      );
+      return;
+    }
+
+    super.setVisible(visible);
+    if (!visible) {
+      this.menu?.hide();
+    }
+  }
+
+  public connect(menu: Menu): DisconnectFn {
+    if (this.menu) {
+      throw new Error(
+        "NavbarMenuButton already connected to a menu, cannot reconnect",
+      );
+    }
+
+    this.menu = menu;
+
+    const clickHandler = (): void => {
+      if (menu.isOpen) {
+        menu.hide();
+      } else {
+        menu.show();
+      }
+    };
+    this.node.addEventListener("click", clickHandler);
+
+    const unsubscribeMenu = menu.subscribe((open): void => {
+      this.node.classList.toggle("isOpen", open);
+    });
+
+    let hasUnbound = false;
+    return (): void => {
+      if (hasUnbound) {
+        return;
+      }
+
+      hasUnbound = false;
+      unsubscribeMenu();
+      this.node.removeEventListener("click", clickHandler);
+      this.node.classList.remove("isOpen");
+      this.menu = null;
+    };
+  }
+}
+
+export default NavbarMenuButton;

--- a/symfony/assets/scripts/class/navbar/NavbarOverflowMenuButton.ts
+++ b/symfony/assets/scripts/class/navbar/NavbarOverflowMenuButton.ts
@@ -1,0 +1,41 @@
+import NavbarElement from "./NavbarElement";
+import type Menu from "./Menu";
+
+class NavbarOverflowMenuButton extends NavbarElement<HTMLButtonElement> {
+  private menu: Menu | null = null;
+
+  public constructor(node: HTMLButtonElement) {
+    super(node);
+  }
+
+  public get width(): number {
+    return this.node.clientWidth;
+  }
+
+  public setVisible(visible: boolean): void {
+    super.setVisible(visible);
+    if (!visible) {
+      this.menu?.hide();
+    }
+  }
+
+  public connect(menu: Menu): void {
+    if (menu === this.menu) {
+      return;
+    }
+
+    this.menu = menu;
+    this.node.addEventListener("click", (): void => {
+      if (menu.isOpen) {
+        menu.hide();
+      } else {
+        menu.show();
+      }
+    });
+    menu.subscribe((open): void => {
+      this.node.classList.toggle("isOpen", open);
+    });
+  }
+}
+
+export default NavbarOverflowMenuButton;

--- a/symfony/assets/scripts/entry/general.ts
+++ b/symfony/assets/scripts/entry/general.ts
@@ -5,6 +5,7 @@ import AgeAndSfwConfig from "../class/AgeAndSfwConfig";
 import "../../styles/general.scss";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 import "bootstrap/dist/css/bootstrap.min.css";
+import Navbar from "../class/navbar/Navbar";
 
 jQuery(() => {
   jQuery("span.utc_datetime").each((index, element) => {
@@ -39,3 +40,5 @@ jQuery(() => {
     config.save();
   });
 });
+
+jQuery(() => Navbar.init());

--- a/symfony/assets/styles/general.scss
+++ b/symfony/assets/styles/general.scss
@@ -6,15 +6,6 @@ html {
   scroll-behavior: auto !important;
 }
 
-#navbarNav:not(.show) + ul.top-menu-right {
-  flex-direction: row;
-
-  li > a {
-    padding-right: var(--bs-navbar-nav-link-padding-x);
-    padding-left: var(--bs-navbar-nav-link-padding-x);
-  }
-}
-
 div.footer {
   font-size: 75%;
 }

--- a/symfony/assets/styles/general.scss
+++ b/symfony/assets/styles/general.scss
@@ -1,4 +1,5 @@
 @import "../../node_modules/bootstrap/scss/bootstrap";
+@import "./navbar";
 
 html {
   // FIXME: https://github.com/symfony/panther/issues/502#issuecomment-1004734763

--- a/symfony/assets/styles/general.scss
+++ b/symfony/assets/styles/general.scss
@@ -5,10 +5,6 @@ html {
   scroll-behavior: auto !important;
 }
 
-nav.navbar .navbar-nav .nav-link .always-full-opacity {
-  color: var(--bs-navbar-hover-color);
-}
-
 #navbarNav:not(.show) + ul.top-menu-right {
   flex-direction: row;
 

--- a/symfony/assets/styles/navbar.scss
+++ b/symfony/assets/styles/navbar.scss
@@ -18,9 +18,10 @@ $menu-z-index: 100;
     white-space: nowrap;
     overflow: hidden;
     position: relative;
-    padding: 16px $navbar-horizontal-padding;
+    padding: 14px $navbar-horizontal-padding;
     background-color: $navbar-bg;
     gap: $navbar-item-gap;
+    height: 72px;
 
     &:not(.initialized) {
       // Visually hide the contents of the navbar until we've run our layout function at least
@@ -50,6 +51,11 @@ $menu-z-index: 100;
       color: var(--bs-nav-link-color);
       padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
 
+      // Vertically and horizontally center the content
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
       &:hover,
       &:focus {
         color: var(--bs-nav-link-hover-color);
@@ -61,6 +67,15 @@ $menu-z-index: 100;
 
       &.isOpen {
         transform: scaleY(-100%);
+      }
+    }
+
+    .nav-mobile-drawer-button {
+      width: 44px;
+      height: 44px;
+
+      i.fas {
+        font-size: 24px;
       }
     }
 

--- a/symfony/assets/styles/navbar.scss
+++ b/symfony/assets/styles/navbar.scss
@@ -1,9 +1,13 @@
+@use "sass:color";
+
 $navbar-bg: #f8f9fa;
 $navbar-horizontal-padding: 12px;
 $navbar-item-gap: 12px;
+$menu-z-index: 100;
 
 .navbar {
   padding: 0;
+  position: relative;
 
   .navbar-main {
     flex: 1;
@@ -29,11 +33,66 @@ $navbar-item-gap: 12px;
       }
     }
 
+    .nav-overflow-menu-button {
+      cursor: pointer;
+      border: none;
+      background: none;
+      transition: transform 150ms;
+      color: var(--bs-nav-link-color);
+
+      &:hover,
+      &:focus {
+        color: var(--bs-nav-link-hover-color);
+      }
+
+      &.isOpen {
+        transform: scaleY(-100%);
+      }
+    }
+
     .hidden {
       visibility: hidden;
       position: absolute;
       pointer-events: none;
       user-select: none;
+    }
+  }
+
+  .nav-menu-backdrop {
+    position: absolute;
+    display: none;
+    top: 100%;
+    left: 0;
+    width: 100vw;
+    height: calc(100vh - 100%);
+    z-index: #{$menu-z-index - 1};
+    background: rgba(white, 0.75);
+
+    &.visible {
+      display: block;
+    }
+  }
+
+  .nav-menu {
+    position: absolute;
+    display: none;
+    right: 16px;
+    bottom: 0;
+    transform: translateY(100%);
+    z-index: $menu-z-index;
+    background-color: color.scale($color: $navbar-bg, $lightness: 50%);
+    border: 1px solid var(--bs-border-color);
+    border-top: 0;
+    padding: 8px $navbar-horizontal-padding;
+
+    &.visible {
+      display: block;
+    }
+
+    .hidden {
+      // Hidden items in the dropdown menu don't need to be displayed at all,
+      // since we aren't using them to measure with
+      display: none;
     }
   }
 
@@ -67,5 +126,14 @@ $navbar-item-gap: 12px;
     i.fas {
       font-size: 1.2rem;
     }
+  }
+}
+
+body.nav-menu-open {
+  overflow: hidden;
+  pointer-events: none;
+
+  .navbar {
+    pointer-events: all;
   }
 }

--- a/symfony/assets/styles/navbar.scss
+++ b/symfony/assets/styles/navbar.scss
@@ -33,17 +33,21 @@ $menu-z-index: 100;
       }
     }
 
-    .nav-overflow-menu-button {
+    button {
       cursor: pointer;
       border: none;
       background: none;
-      transition: transform 150ms;
       color: var(--bs-nav-link-color);
+      padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
 
       &:hover,
       &:focus {
         color: var(--bs-nav-link-hover-color);
       }
+    }
+
+    .nav-overflow-menu-button {
+      transition: transform 150ms;
 
       &.isOpen {
         transform: scaleY(-100%);
@@ -73,26 +77,58 @@ $menu-z-index: 100;
     }
   }
 
-  .nav-menu {
+  .nav-dropdown-menu,
+  .nav-drawer-menu {
     position: absolute;
-    display: none;
-    right: 16px;
-    bottom: 0;
-    transform: translateY(100%);
-    z-index: $menu-z-index;
     background-color: color.scale($color: $navbar-bg, $lightness: 50%);
-    border: 1px solid var(--bs-border-color);
-    border-top: 0;
+    z-index: $menu-z-index;
     padding: 8px $navbar-horizontal-padding;
-
-    &.visible {
-      display: block;
-    }
 
     .hidden {
       // Hidden items in the dropdown menu don't need to be displayed at all,
       // since we aren't using them to measure with
       display: none;
+    }
+  }
+
+  .nav-dropdown-menu {
+    display: none;
+
+    right: 16px;
+    bottom: 0;
+    transform: translateY(100%);
+
+    border: 1px solid var(--bs-border-color);
+    border-top: 0;
+
+    &.visible {
+      display: block;
+    }
+  }
+
+  .nav-drawer-menu {
+    left: 0;
+    top: 100%;
+    height: calc(100vh - 100%);
+    width: 50vw;
+    transition:
+      transform 100ms,
+      opacity 100ms ease-out;
+
+    transform: translateX(-100%);
+    pointer-events: none;
+    user-select: none;
+    opacity: 0;
+
+    border-right: 1px solid var(--bs-border-color);
+
+    overflow: auto;
+
+    &.visible {
+      transform: translateX(0);
+      pointer-events: unset;
+      user-select: unset;
+      opacity: 1;
     }
   }
 

--- a/symfony/assets/styles/navbar.scss
+++ b/symfony/assets/styles/navbar.scss
@@ -22,6 +22,16 @@ $menu-z-index: 100;
     background-color: $navbar-bg;
     gap: $navbar-item-gap;
 
+    &:not(.initialized) {
+      // Visually hide the contents of the navbar until we've run our layout function at least
+      // once in JS. If we don't do that, users will see the initial render frame flicker with
+      // all of the navbar items, and then immediately update after we run the layout.
+      // The delay isn't enough that most people will perceive the items not being there for
+      // the first render frame, but it IS enough to the navbar items be there and then
+      // disappear.
+      opacity: 0;
+    }
+
     .nav-separator {
       flex: 1;
 

--- a/symfony/assets/styles/navbar.scss
+++ b/symfony/assets/styles/navbar.scss
@@ -1,10 +1,48 @@
+$navbar-bg: #f8f9fa;
+$navbar-horizontal-padding: 12px;
+$navbar-item-gap: 12px;
+
 .navbar {
+  padding: 0;
+
+  .navbar-main {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    justify-content: start;
+    flex-wrap: nowrap;
+    white-space: nowrap;
+    overflow: hidden;
+    position: relative;
+    padding: 16px $navbar-horizontal-padding;
+    background-color: $navbar-bg;
+    gap: $navbar-item-gap;
+
+    .nav-separator {
+      flex: 1;
+
+      &.hidden {
+        // Separator doesn't need to be measured for its width, so when the separator is hidden
+        // we should COMPLETELY hide it. If we don't do so, we'll continue to display a double
+        // gap separating the two sides
+        display: none;
+      }
+    }
+
+    .hidden {
+      visibility: hidden;
+      position: absolute;
+      pointer-events: none;
+      user-select: none;
+    }
+  }
+
   .nav-link {
     display: flex;
     align-items: center;
     gap: 0.25rem;
 
-    .navlink-label {
+    .label {
       display: grid;
       grid-template-columns: 1fr;
       grid-template-rows: 1fr;
@@ -16,12 +54,12 @@
       }
     }
 
-    &.active .navlink-label .displayed,
-    .navlink-label .spacer {
+    &.active .label .displayed,
+    .label .spacer {
       font-weight: bold;
     }
 
-    .navlink-label .spacer {
+    .label .spacer {
       opacity: 0;
       user-select: none;
     }

--- a/symfony/assets/styles/navbar.scss
+++ b/symfony/assets/styles/navbar.scss
@@ -1,0 +1,33 @@
+.navbar {
+  .nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+
+    .navlink-label {
+      display: grid;
+      grid-template-columns: 1fr;
+      grid-template-rows: 1fr;
+      grid-template-areas: "cell";
+
+      .spacer,
+      .displayed {
+        grid-area: cell;
+      }
+    }
+
+    &.active .navlink-label .displayed,
+    .navlink-label .spacer {
+      font-weight: bold;
+    }
+
+    .navlink-label .spacer {
+      opacity: 0;
+      user-select: none;
+    }
+
+    i.fas {
+      font-size: 1.2rem;
+    }
+  }
+}

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -14,5 +14,10 @@
         {{ include('_menu_item.html.twig', {name: 'iu_form_step_start', fa_icon: 'user-gear', label: 'Fursuit Makers', priority: 'medium'}) }}
         {{ include('_menu_item.html.twig', {name: 'donate', fa_icon: 'circle-dollar-to-slot', label: 'Donate', priority: 'medium'}) }}
         {{ include('_menu_item.html.twig', {name: 'contact', fa_icon: 'envelope', label: 'Contact', priority: 'medium'}) }}
+        <button class="nav-overflow-menu-button">
+            <i class="fa-solid fa-chevron-down"></i>
+        </button>
     </div>
+    <div class="nav-menu-backdrop"></div>
+    <div class="nav-menu navbar-nav"></div>
 </nav>

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -6,24 +6,24 @@
 
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                {{ include('_menu_item.html.twig', {name: 'main', pretty_name: '<i class="fas fa-home"></i> Home'}) }}
-                {{ include('_menu_item.html.twig', {name: 'iu_form_step_start', pretty_name: '<i class="fas fa-user-plus"></i> Join/update'}) }}
-                {{ include('_menu_item.html.twig', {name: 'info', pretty_name: '<i class="fas fa-question-circle"></i> Information'}) }}
-                {{ include('_menu_item.html.twig', {name: 'maker_ids', pretty_name: '<i class="fas fa-id-badge"></i> Maker IDs'}) }}
-                {{ include('_menu_item.html.twig', {name: 'events', pretty_name: '<i class="fas fa-history"></i> Updates'}) }}
+                {{ include('_menu_item.html.twig', {name: 'main', fa_icon: 'home', label: 'Home'}) }}
+                {{ include('_menu_item.html.twig', {name: 'iu_form_step_start', fa_icon: 'user-plus', label: 'Join/update'}) }}
+                {{ include('_menu_item.html.twig', {name: 'info', fa_icon: 'question-circle', label: 'Information'}) }}
+                {{ include('_menu_item.html.twig', {name: 'maker_ids', fa_icon: 'id-badge', label: 'Maker IDs'}) }}
+                {{ include('_menu_item.html.twig', {name: 'events', fa_icon: 'history', label: 'Updates'}) }}
                 {% if isDevEnv() %}
-                    {{ include('_menu_item.html.twig', {name: 'mx_artisan_new', pretty_name: '<i class="fas fa-plus"></i> Maker'}) }}
-                    {{ include('_menu_item.html.twig', {name: 'mx_event_new', pretty_name: '<i class="fas fa-plus"></i> Event'}) }}
-                    {{ include('_menu_item.html.twig', {name: 'mx_artisan_urls', pretty_name: '<i class="fas fa-link"></i> URLs'}) }}
-                    {{ include('_menu_item.html.twig', {name: 'mx_query', pretty_name: '<i class="fas fa-filter"></i> Query'}) }}
-                    {{ include('_menu_item.html.twig', {name: 'mx_submissions', pretty_name: '<i class="fa-solid fa-file-lines"></i> Submissions'}) }}
+                    {{ include('_menu_item.html.twig', {name: 'mx_artisan_new', fa_icon: 'plus', label: 'Maker'}) }}
+                    {{ include('_menu_item.html.twig', {name: 'mx_event_new', fa_icon: 'plus', label: 'Event'}) }}
+                    {{ include('_menu_item.html.twig', {name: 'mx_artisan_urls', fa_icon: 'link', label: 'URLs'}) }}
+                    {{ include('_menu_item.html.twig', {name: 'mx_query', fa_icon: 'filter', label: 'Query'}) }}
+                    {{ include('_menu_item.html.twig', {name: 'mx_submissions', fa_icon: 'file-lines', label: 'Submissions'}) }}
                 {% endif %}
             </ul>
         </div>
 
         <ul class="navbar-nav d-flex top-menu-right">
-            {{ include('_menu_item.html.twig', {name: 'contact', pretty_name: '<i class="fa-solid fa-envelope"></i> Contact'}) }}
-            {{ include('_menu_item.html.twig', {name: 'donate', pretty_name: '<span class="always-full-opacity">🥌</span>️ Donate'}) }}
+            {{ include('_menu_item.html.twig', {name: 'contact', fa_icon: 'envelope', label: 'Contact'}) }}
+            {{ include('_menu_item.html.twig', {name: 'donate', fa_icon: 'circle-dollar-to-slot', label: 'Donate'}) }}
         </ul>
     </div>
 </nav>

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -15,10 +15,10 @@
         {{ include('_menu_item.html.twig', {name: 'donate', fa_icon: 'circle-dollar-to-slot', label: 'Donate', priority: 'medium'}) }}
         {{ include('_menu_item.html.twig', {name: 'contact', fa_icon: 'envelope', label: 'Contact', priority: 'medium'}) }}
         <button class="nav-overflow-menu-button">
-            <i class="fa-solid fa-chevron-down"></i>
+            <i class="fas fa-chevron-down"></i>
         </button>
         <button class="nav-mobile-drawer-button">
-            <i class="fa-solid fa-bars"></i>
+            <i class="fas fa-bars"></i>
         </button>
     </div>
     <div class="nav-menu-backdrop"></div>

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -1,28 +1,18 @@
-<nav class="navbar navbar-expand-lg bg-body-tertiary mb-2">
-    <div class="container-fluid">
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                {{ include('_menu_item.html.twig', {name: 'main', fa_icon: 'home', label: 'Home'}) }}
-                {{ include('_menu_item.html.twig', {name: 'info', fa_icon: 'circle-info', label: 'About'}) }}
-                {{ include('_menu_item.html.twig', {name: 'events', fa_icon: 'newspaper', label: 'News'}) }}
-                {% if isDevEnv() %}
-                    {{ include('_menu_item.html.twig', {name: 'mx_artisan_new', fa_icon: 'plus', label: 'Maker'}) }}
-                    {{ include('_menu_item.html.twig', {name: 'mx_event_new', fa_icon: 'plus', label: 'Event'}) }}
-                    {{ include('_menu_item.html.twig', {name: 'mx_artisan_urls', fa_icon: 'link', label: 'URLs'}) }}
-                    {{ include('_menu_item.html.twig', {name: 'mx_query', fa_icon: 'filter', label: 'Query'}) }}
-                    {{ include('_menu_item.html.twig', {name: 'mx_submissions', fa_icon: 'file-lines', label: 'Submissions'}) }}
-                {% endif %}
-            </ul>
-        </div>
-
-        <ul class="navbar-nav d-flex top-menu-right">
-            {{ include('_menu_item.html.twig', {name: 'iu_form_step_start', fa_icon: 'user-gear', label: 'Fursuit Makers'}) }}
-            {{ include('_menu_item.html.twig', {name: 'donate', fa_icon: 'circle-dollar-to-slot', label: 'Donate'}) }}
-            {{ include('_menu_item.html.twig', {name: 'contact', fa_icon: 'envelope', label: 'Contact'}) }}
-        </ul>
+<nav id="navbar" class="navbar mb-2">
+    <div class="navbar-main navbar-nav">
+        {{ include('_menu_item.html.twig', {name: 'main', fa_icon: 'home', label: 'Home', priority: 'high'}) }}
+        {{ include('_menu_item.html.twig', {name: 'info', fa_icon: 'circle-info', label: 'About', priority: 'high'}) }}
+        {{ include('_menu_item.html.twig', {name: 'events', fa_icon: 'newspaper', label: 'News', priority: 'high'}) }}
+        {% if isDevEnv() %}
+            {{ include('_menu_item.html.twig', {name: 'mx_artisan_new', fa_icon: 'plus', label: 'Maker', priority: 'low'}) }}
+            {{ include('_menu_item.html.twig', {name: 'mx_event_new', fa_icon: 'plus', label: 'Event', priority: 'low'}) }}
+            {{ include('_menu_item.html.twig', {name: 'mx_artisan_urls', fa_icon: 'link', label: 'URLs', priority: 'low'}) }}
+            {{ include('_menu_item.html.twig', {name: 'mx_query', fa_icon: 'filter', label: 'Query', priority: 'low'}) }}
+            {{ include('_menu_item.html.twig', {name: 'mx_submissions', fa_icon: 'file-lines', label: 'Submissions', priority: 'low'}) }}
+        {% endif %}
+        <div class="nav-separator"></div>
+        {{ include('_menu_item.html.twig', {name: 'iu_form_step_start', fa_icon: 'user-gear', label: 'Fursuit Makers', priority: 'medium'}) }}
+        {{ include('_menu_item.html.twig', {name: 'donate', fa_icon: 'circle-dollar-to-slot', label: 'Donate', priority: 'medium'}) }}
+        {{ include('_menu_item.html.twig', {name: 'contact', fa_icon: 'envelope', label: 'Contact', priority: 'medium'}) }}
     </div>
 </nav>

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -17,7 +17,10 @@
         <button class="nav-overflow-menu-button">
             <i class="fa-solid fa-chevron-down"></i>
         </button>
+        <button class="nav-mobile-drawer-button">
+            <i class="fa-solid fa-bars"></i>
+        </button>
     </div>
     <div class="nav-menu-backdrop"></div>
-    <div class="nav-menu navbar-nav"></div>
+    <div class="nav-dropdown-menu navbar-nav"></div>
 </nav>

--- a/symfony/templates/_menu.html.twig
+++ b/symfony/templates/_menu.html.twig
@@ -7,10 +7,8 @@
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 {{ include('_menu_item.html.twig', {name: 'main', fa_icon: 'home', label: 'Home'}) }}
-                {{ include('_menu_item.html.twig', {name: 'iu_form_step_start', fa_icon: 'user-plus', label: 'Join/update'}) }}
-                {{ include('_menu_item.html.twig', {name: 'info', fa_icon: 'question-circle', label: 'Information'}) }}
-                {{ include('_menu_item.html.twig', {name: 'maker_ids', fa_icon: 'id-badge', label: 'Maker IDs'}) }}
-                {{ include('_menu_item.html.twig', {name: 'events', fa_icon: 'history', label: 'Updates'}) }}
+                {{ include('_menu_item.html.twig', {name: 'info', fa_icon: 'circle-info', label: 'About'}) }}
+                {{ include('_menu_item.html.twig', {name: 'events', fa_icon: 'newspaper', label: 'News'}) }}
                 {% if isDevEnv() %}
                     {{ include('_menu_item.html.twig', {name: 'mx_artisan_new', fa_icon: 'plus', label: 'Maker'}) }}
                     {{ include('_menu_item.html.twig', {name: 'mx_event_new', fa_icon: 'plus', label: 'Event'}) }}
@@ -22,8 +20,9 @@
         </div>
 
         <ul class="navbar-nav d-flex top-menu-right">
-            {{ include('_menu_item.html.twig', {name: 'contact', fa_icon: 'envelope', label: 'Contact'}) }}
+            {{ include('_menu_item.html.twig', {name: 'iu_form_step_start', fa_icon: 'user-gear', label: 'Fursuit Makers'}) }}
             {{ include('_menu_item.html.twig', {name: 'donate', fa_icon: 'circle-dollar-to-slot', label: 'Donate'}) }}
+            {{ include('_menu_item.html.twig', {name: 'contact', fa_icon: 'envelope', label: 'Contact'}) }}
         </ul>
     </div>
 </nav>

--- a/symfony/templates/_menu_item.html.twig
+++ b/symfony/templates/_menu_item.html.twig
@@ -1,5 +1,5 @@
 {% set is_active = app.request.attributes.get('_route') == name %}
 
 <li class="nav-item">
-    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}">{{ pretty_name|raw }}</a>
+    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}"><i class="fas fa-{{ fa_icon }}"></i> {{ label }}</a>
 </li>

--- a/symfony/templates/_menu_item.html.twig
+++ b/symfony/templates/_menu_item.html.twig
@@ -1,11 +1,16 @@
 {% set is_active = app.request.attributes.get('_route') == name %}
 
-<li class="nav-item">
-    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}">
-        <i class="fas fa-{{ fa_icon }}"></i>
-        <span class="navlink-label">
-          <div class="spacer">{{ label }}</div>
-          <div class="displayed">{{ label }}</div>
-        </span>
-    </a>
-</li>
+<a
+    {% if priority is defined %}data-priority="{{ priority }}"{% endif %}
+    class="{{ html_classes('nav-link', {
+        active: is_active
+    }) }}"
+    {% if is_active %}aria-current="page"{% endif %}
+    href="{{ path(name) }}"
+>
+    <i class="fas fa-{{ fa_icon }}"></i>
+    <span class="label">
+        <div class="spacer">{{ label }}</div>
+        <div class="displayed">{{ label }}</div>
+    </span>
+</a>

--- a/symfony/templates/_menu_item.html.twig
+++ b/symfony/templates/_menu_item.html.twig
@@ -10,7 +10,9 @@
 >
     <i class="fas fa-{{ fa_icon }}"></i>
     <span class="label">
-        <div class="spacer">{{ label }}</div>
+        {# Spacer is responsible to hold style of the "active" link while being invisible.
+           This is to remove width changes of the menu items when displayed page changes. #}
+        <div class="spacer" aria-hidden="true">{{ label }}</div>
         <div class="displayed">{{ label }}</div>
     </span>
 </a>

--- a/symfony/templates/_menu_item.html.twig
+++ b/symfony/templates/_menu_item.html.twig
@@ -1,5 +1,11 @@
 {% set is_active = app.request.attributes.get('_route') == name %}
 
 <li class="nav-item">
-    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}"><i class="fas fa-{{ fa_icon }}"></i> {{ label }}</a>
+    <a class="nav-link {% if is_active %}active{% endif %}" {% if is_active %}aria-current="page"{% endif %} href="{{ path(name) }}">
+        <i class="fas fa-{{ fa_icon }}"></i>
+        <span class="navlink-label">
+          <div class="spacer">{{ label }}</div>
+          <div class="displayed">{{ label }}</div>
+        </span>
+    </a>
 </li>


### PR DESCRIPTION
## Description

In this PR, I'm replacing our current navigation bar implementation with a more customized one. This creates a responsive navbar manager. It keeps track of how many items are in the navbar, and whenever the navbar is resized, it will figure out which items can fit. It updates the layout and removes links that can't fit, putting them into an overflow dropdown menu.

https://github.com/user-attachments/assets/697ea9f9-f4d5-4ac6-be14-848b5c0b76a3

When there's 500px or less, we switch over to a dedicated mobile layout. This removes all links from the header, leaving only a hamburger menu button. This button opens a mobile drawer from the side that displays all of the links inside.

https://github.com/user-attachments/assets/d06df2b1-dca4-446f-89d0-657bca9d1ad0

I've attempted to keep this implementation as simple as possible, and I've iterated on this solution maybe a dozen times to ensure it's as straightforward and simple as possible.

This kind of navbar approach is typical for websites with more than a couple of links in their navbar. I wanted to put in the effort now so we could permanently solve some issues around spacing, but also because I would like to explore adding more types of items to the navbar (starting with a logo), and to update the overall design of the website. I've specifically built this code to be easy to update and expand on.

I've tested this in Arc (Chromium), Firefox, desktop Safari, and iOS Safari. There were no issues in the latest versions of any of these browsers.